### PR TITLE
Fix login error handling and registration result output

### DIFF
--- a/application/controllers/userscontroller.php
+++ b/application/controllers/userscontroller.php
@@ -21,7 +21,7 @@ class UsersController extends Controller
     {
 
         if (!isset($_POST['loginSubmit'])) {
-            header('Location : /users/index');
+            header('Location: /users/index');
         }
 
 
@@ -54,7 +54,7 @@ class UsersController extends Controller
         } catch (Exception $e) {
             $this->_setView('result');
             $this->_view->set('error', 'Login failure!');
-            $this->_view->set('loginerror' . $e->getMessage());
+            $this->_view->set('loginerror', $e->getMessage());
         }
         $login = false;
         return $this->_view->output();

--- a/application/views/users/result.tpl
+++ b/application/views/users/result.tpl
@@ -38,17 +38,17 @@
         }
         ?>
         <?php if(isset($userData)){ ?>
-        <h2>Registed data</h2>
+        <h2>Registered data</h2>
         <div class="formregis">
-            <label>Username</label><input value='<?php if(isset($userData)) echo $userData[' userName']; ?>' type="text"
+            <label>Username</label><input value='<?php if(isset($userData)) echo $userData['userName']; ?>' type="text"
             name="username" disabled><br>
-            <label>Name</label><input value='<?php if(isset($userData)) echo $userData[' firstName']; ?>' type="text"
+            <label>Name</label><input value='<?php if(isset($userData)) echo $userData['firstName']; ?>' type="text"
             name="name" disabled><br>
-            <label>LastName</label><input value='<?php if(isset($userData)) echo $userData[' lastName']; ?>' type="text"
+            <label>LastName</label><input value='<?php if(isset($userData)) echo $userData['lastName']; ?>' type="text"
             name="last_name" disabled><br>
-            <label>Email</label><input value='<?php if(isset($userData)) echo $userData[' email']; ?>' type="text"
+            <label>Email</label><input value='<?php if(isset($userData)) echo $userData['email']; ?>' type="text"
             name="email" disabled><br>
-            <label>Password</label><input value='<?php if(isset($userData)) echo $userData[' password']; ?>'
+            <label>Password</label><input value='<?php if(isset($userData)) echo $userData['password']; ?>'
             type="password" name="password" disabled><br>
         </div>
         <a href="/users/index">Back to index</a>


### PR DESCRIPTION
## Summary
- correct header call and login error setter in `UsersController`
- fix misspellings and array keys in `users/result.tpl`

## Testing
- `php -l application/controllers/userscontroller.php`
- `php -l application/views/users/result.tpl`


------
https://chatgpt.com/codex/tasks/task_e_68405aea13b4832d8ecbbe642cbf908f